### PR TITLE
Use Polymer/core-animation instead of manual CSS animations.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "font-roboto": "Polymer/font-roboto#master",
-    "paper-radio-button": "Polymer/paper-radio-button#master"
+    "paper-radio-button": "Polymer/paper-radio-button#master",
+    "core-animation": "Polymer/core-animation#master"
   }
 }

--- a/paper-checkbox.css
+++ b/paper-checkbox.css
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   position: absolute;
   box-sizing: border-box;
   top: 0px;
-  left: 0px; 
+  left: 0px;
   width: 18px;
   height: 18px;
   border: solid 2px;
@@ -55,90 +55,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   pointer-events: none;
 }
 
-/* checkbox checked animations */
+/* checkbox checked states */
 #checkbox.checked.box {
   border: solid 2px;
-  -webkit-animation: box-shrink 140ms ease-out forwards;
-  animation: box-shrink 140ms ease-out forwards;
-}
-
-@-webkit-keyframes box-shrink {
-  0% {
-    -webkit-transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-  100% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-@keyframes box-shrink {
-  0% {
-    transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-  100% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
 }
 
 #checkbox.checked.checkmark {
   border-left: none;
   border-top: none;
-  -webkit-animation: checkmark-expand 140ms ease-out forwards;
-  animation: checkmark-expand 140ms ease-out forwards;
-}
-
-@-webkit-keyframes checkmark-expand {
-  0% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    -webkit-transform: rotate(45deg);
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
-}
-
-@keyframes checkmark-expand {
-  0% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    transform: rotate(45deg);
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
 }
 
 #checkbox.checked {
@@ -155,87 +79,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   border-color: #0f9d58;
 }
 
-/* checkbox unchecked animations */
+/* checkbox unchecked state */
 #checkbox.unchecked.checkmark {
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   border-left: none;
   border-top: none;
-  -webkit-animation: checkmark-shrink 140ms ease-out forwards;
-  animation: checkmark-shrink 140ms ease-out forwards;
-}
-
-@-webkit-keyframes checkmark-shrink {
-  0% {
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
-  100% {
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-@keyframes checkmark-shrink {
-  0% {
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
-  100% {
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-#checkbox.unchecked.box {
-  -webkit-animation: box-expand 140ms ease-out forwards;
-  animation: box-expand 140ms ease-out forwards;
-}
-
-@-webkit-keyframes box-expand {
-  0% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    -webkit-transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-}
-
-@keyframes box-expand {
-  0% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
 }
 
 /* label */

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -19,7 +19,7 @@ Example:
     <paper-checkbox></paper-checkbox>
 
     <paper-checkbox checked></paper-checkbox>
-    
+
 Styling checkbox:
 
 To change the ink color for checked state:
@@ -27,7 +27,7 @@ To change the ink color for checked state:
     paper-checkbox::shadow #ink[checked] {
       color: #4285f4;
     }
-    
+
 To change the checkbox checked color:
 
     paper-checkbox::shadow #checkbox.checked {
@@ -53,6 +53,7 @@ To change the checbox unchecked color:
 -->
 
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
+<link rel="import" href="../core-animation/core-animation.html">
 
 <polymer-element name="paper-checkbox" extends="paper-radio-button" role="checkbox">
 <template>
@@ -60,51 +61,150 @@ To change the checbox unchecked color:
   <link rel="stylesheet" href="paper-checkbox.css">
 
   <div id="checkboxContainer" class="{{ {labeled: label} | tokenList }}" >
-  
+
     <paper-ripple id="ink" class="circle recenteringTouch" checked?="{{!checked}}"></paper-ripple>
-     
-    <div id="checkbox" on-animationend="{{checkboxAnimationEnd}}" on-webkitAnimationEnd="{{checkboxAnimationEnd}}"></div>
-    
+
+    <div id="checkbox"></div>
+
+    <!-- checkbox checked animations -->
+
+    <core-animation id="box_shrink" duration="140" fill="forwards" easing="ease-out" on-core-animation-finish="{{checkboxAnimationEnd}}">
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(0deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="0px"></core-animation-prop>
+        <core-animation-prop name="left" value="0px"></core-animation-prop>
+        <core-animation-prop name="width" value="18px"></core-animation-prop>
+        <core-animation-prop name="height" value="18px"></core-animation-prop>
+      </core-animation-keyframe>
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(45deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="13px"></core-animation-prop>
+        <core-animation-prop name="left" value="5px"></core-animation-prop>
+        <core-animation-prop name="width" value="4px"></core-animation-prop>
+        <core-animation-prop name="height" value="4px"></core-animation-prop>
+      </core-animation-keyframe>
+    </core-animation>
+
+    <core-animation id="checkmark_expand" duration="140" fill="forwards" easing="ease-out" on-core-animation-finish="{{checkboxAnimationEnd}}">
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(45deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="13px"></core-animation-prop>
+        <core-animation-prop name="left" value="5px"></core-animation-prop>
+        <core-animation-prop name="width" value="4px"></core-animation-prop>
+        <core-animation-prop name="height" value="4px"></core-animation-prop>
+      </core-animation-keyframe>
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(45deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="-4px"></core-animation-prop>
+        <core-animation-prop name="left" value="6px"></core-animation-prop>
+        <core-animation-prop name="width" value="10px"></core-animation-prop>
+        <core-animation-prop name="height" value="21px"></core-animation-prop>
+        <core-animation-prop name="border-right-width" value="2px"></core-animation-prop>
+        <core-animation-prop name="border-bottom-width" value="2px"></core-animation-prop>
+      </core-animation-keyframe>
+    </core-animation>
+
+    <!-- checkbox unchecked animations -->
+
+    <core-animation id="checkmark_shrink" duration="140" fill="forwards" easing="ease-out" on-core-animation-finish="{{checkboxAnimationEnd}}">
+      <core-animation-keyframe>
+        <core-animation-prop name="top" value="-4px"></core-animation-prop>
+        <core-animation-prop name="left" value="6px"></core-animation-prop>
+        <core-animation-prop name="width" value="10px"></core-animation-prop>
+        <core-animation-prop name="height" value="21px"></core-animation-prop>
+        <core-animation-prop name="border-right-width" value="2px"></core-animation-prop>
+        <core-animation-prop name="border-bottom-width" value="2px"></core-animation-prop>
+      </core-animation-keyframe>
+      <core-animation-keyframe>
+        <core-animation-prop name="top" value="13px"></core-animation-prop>
+        <core-animation-prop name="left" value="5px"></core-animation-prop>
+        <core-animation-prop name="width" value="4px"></core-animation-prop>
+        <core-animation-prop name="height" value="4px"></core-animation-prop>
+      </core-animation-keyframe>
+    </core-animation>
+
+    <core-animation id="box_expand" duration="140" fill="forwards" easing="ease-out" on-core-animation-finish="{{checkboxAnimationEnd}}">
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(45deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="13px"></core-animation-prop>
+        <core-animation-prop name="left" value="5px"></core-animation-prop>
+        <core-animation-prop name="width" value="4px"></core-animation-prop>
+        <core-animation-prop name="height" value="4px"></core-animation-prop>
+      </core-animation-keyframe>
+      <core-animation-keyframe>
+        <core-animation-prop name="transform" value="rotate(0deg)"></core-animation-prop>
+        <core-animation-prop name="top" value="0px"></core-animation-prop>
+        <core-animation-prop name="left" value="0px"></core-animation-prop>
+        <core-animation-prop name="width" value="18px"></core-animation-prop>
+        <core-animation-prop name="height" value="18px"></core-animation-prop>
+      </core-animation-keyframe>
+    </core-animation>
+
   </div>
-  
+
   <div id="checkboxLabel" hidden?="{{!label}}">{{label}}<content></content></div>
 
 </template>
 <script>
 
-  Polymer('paper-checkbox', {
-    
-    /**
-     * Fired when the checked state changes due to user interaction.
-     *
-     * @event change
-     */
-     
-    /**
-     * Fired when the checked state changes.
-     *
-     * @event core-change
-     */
-    
-    toggles: true,
+	Polymer('paper-checkbox', {
 
-    checkedChanged: function() {
-      var cl = this.$.checkbox.classList;
-      cl.toggle('checked', this.checked);
-      cl.toggle('unchecked', !this.checked);
-      cl.toggle('checkmark', !this.checked);
-      cl.toggle('box', this.checked);
-      this.setAttribute('aria-checked', this.checked ? 'true': 'false');
-      this.fire('core-change');
-    },
+		/**
+		* Fired when the checked state changes due to user interaction.
+		*
+		* @event change
+		*/
 
-    checkboxAnimationEnd: function() {
-      var cl = this.$.checkbox.classList;
-      cl.toggle('checkmark', this.checked && !cl.contains('checkmark'));
-      cl.toggle('box', !this.checked && !cl.contains('box'));
-    }
+		/**
+		* Fired when the checked state changes.
+		*
+		* @event core-change
+		*/
 
-  });
-  
+		toggles: true,
+
+		checkedChanged: function () {
+			var cl = this.$.checkbox.classList;
+			var animation;
+			cl.toggle('checked', this.checked);
+			cl.toggle('unchecked', !this.checked);
+			cl.toggle('checkmark', !this.checked);
+			cl.toggle('box', this.checked);
+			if (this.checked) {
+				animation = this.$.box_shrink;
+				animation.target = this.$.checkbox;
+				animation.play();
+			} else {
+				animation = this.$.checkmark_shrink;
+				animation.target = this.$.checkbox;
+				animation.play();
+			}
+			this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+			this.fire('core-change');
+		},
+
+		checkboxAnimationEnd: function () {
+			var cl = this.$.checkbox.classList;
+			var animation;
+			if (this.checked && !cl.contains('checkmark')) {
+				cl.toggle('checkmark', true);
+				animation = this.$.checkmark_expand;
+				animation.target = this.$.checkbox;
+				animation.play();
+			} else {
+				cl.toggle('checkmark', false);
+			}
+			if (!this.checked && !cl.contains('box')) {
+				cl.toggle('box', true);
+				animation = this.$.box_expand;
+				animation.target = this.$.checkbox;
+				animation.play();
+			} else {
+				cl.toggle('box', false);
+			}
+		}
+
+	});
+
 </script>
 </polymer-element>


### PR DESCRIPTION
CSS Animations don't work in IE9.  It's not just that the animations don't work, but the post-animation callback doesn't get called (so the UI gets stuck in an inconsistent state).

However, [Polymer/core-animations](http://www.polymer-project.org/docs/elements/core-elements.html#core-animation) works in IE9, so I updated <paper-elements/> to use it.

(Sorry for the apparently huge changes to the CSS, all I did was change two comments and remove the CSS animations...  git's diffing tool disagrees.)
