### PR TITLE
Sync paper-checkbox with Material Design

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -41,11 +41,12 @@
     }
     
     paper-checkbox.blue::shadow #ink[checked] {
-      color: #4285f4;
+      color: #BBDEFB;
     }
-    
+
     paper-checkbox.blue::shadow #checkbox.checked {
-      border-color: #4285f4;
+      background-color: #2196F3;
+      border-color: #2196F3;
     }
     
   </style>
@@ -53,58 +54,77 @@
 </head>
 <body unresolved>
   
-  <core-label horizontal layout>
-    <paper-checkbox for></paper-checkbox>
-    <div vertical layout>
-      <h4>Notifications</h4>
-      <div>Notify me about updates to apps or games that I've downloaded</div>
-    </div>
-  </core-label>
-  
-  <br>
-  
-  <core-label horizontal layout>
-    <paper-checkbox checked for></paper-checkbox>
-    <div vertical layout>
-      <h4>Auto-updates</h4>
-      <div>Auto-update apps over wifi only</div>
-    </div>
-  </core-label>
-  
-  <br>
-  
-  <core-label horizontal layout>
-    <paper-checkbox for></paper-checkbox>
-    <div vertical layout>
-      <h4>Clear search history</h4>
-      <div>Remove all the searches you have ever performed</div>
-    </div>
-  </core-label>
-  
-  <br>
-  <br>
-  <br>
-  
   <section>
   
+    <core-label horizontal layout>
+      <paper-checkbox for></paper-checkbox>
+      <div vertical layout>
+        <h4>Notifications</h4>
+        <div>Notify me about updates to apps or games that I've downloaded</div>
+      </div>
+    </core-label>
+
+    <br>
+
+    <core-label horizontal layout>
+      <paper-checkbox checked for></paper-checkbox>
+      <div vertical layout>
+        <h4>Auto-updates</h4>
+        <div>Auto-update apps over wifi only</div>
+      </div>
+    </core-label>
+
+    <br>
+
+    <core-label horizontal layout>
+      <paper-checkbox for></paper-checkbox>
+      <div vertical layout>
+        <h4>Clear search history</h4>
+        <div>Remove all the searches you have ever performed</div>
+      </div>
+    </core-label>
+
+    <br>
+
+    <core-label horizontal layout>
+      <paper-checkbox for disabled checked></paper-checkbox>
+      <div vertical layout>
+        <h4>Use as default browser</h4>
+      </div>
+    </core-label>
+
+    <br>
+
+    <core-label horizontal layout>
+      <paper-checkbox for disabled></paper-checkbox>
+      <div vertical layout>
+        <h4>Allow in incognito</h4>
+      </div>
+    </core-label>
+  </section>
+
+  <br>
+  <br>
+  <br>
+
+  <section>
     <h3>Sound</h3>
-  
+
     <core-label center horizontal layout>
       <div flex>Touch sounds</div>
       <paper-checkbox class="blue" checked for></paper-checkbox>
     </core-label>
-    
+
     <core-label center horizontal layout>
       <div flex>Screen lock sound</div>
       <paper-checkbox class="blue" for></paper-checkbox>
     </core-label>
-    
+
     <core-label center horizontal layout>
       <div flex>Vibrate on touch</div>
       <paper-checkbox class="blue" for></paper-checkbox>
     </core-label>
-  
   </section>
-  
+
 </body>
 </html>

--- a/paper-checkbox.css
+++ b/paper-checkbox.css
@@ -16,6 +16,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   outline: 0;
 }
 
+.hidden {
+  display: none;
+}
+
 #checkboxContainer {
   position: relative;
   width: 18px;
@@ -40,202 +44,75 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 #ink[checked] {
-  color: #0f9d58;
+  color: #B2DFDB;
 }
 
 #checkbox {
-  position: absolute;
+  position: relative;
   box-sizing: border-box;
-  top: 0px;
-  left: 0px; 
-  width: 18px;
-  height: 18px;
-  border: solid 2px;
-  border-color: #5a5a5a;
+  height: 100%;
+  border: solid 2px #5a5a5a;
+  border-radius: 2px;
   pointer-events: none;
+  -webkit-transition: background-color 140ms, border-color 140ms;
+  transition: background-color 140ms, border-color 140ms;
 }
 
 /* checkbox checked animations */
-#checkbox.checked.box {
-  border: solid 2px;
-  -webkit-animation: box-shrink 140ms ease-out forwards;
-  animation: box-shrink 140ms ease-out forwards;
-}
-
-@-webkit-keyframes box-shrink {
-  0% {
-    -webkit-transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-  100% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-@keyframes box-shrink {
-  0% {
-    transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-  100% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-#checkbox.checked.checkmark {
-  border-left: none;
-  border-top: none;
+:host([checked]) #checkmark {
   -webkit-animation: checkmark-expand 140ms ease-out forwards;
   animation: checkmark-expand 140ms ease-out forwards;
 }
 
 @-webkit-keyframes checkmark-expand {
   0% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
+    top: 9px;
+    left: 6px;
+    width: 0px;
+    height: 0px;
   }
   100% {
-    -webkit-transform: rotate(45deg);
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
+    top: -1px;
+    left: 4px;
+    width: 5px;
+    height: 10px;
   }
 }
 
 @keyframes checkmark-expand {
   0% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
+    top: 9px;
+    left: 6px;
+    width: 0px;
+    height: 0px;
   }
   100% {
-    transform: rotate(45deg);
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
+    top: -1px;
+    left: 4px;
+    width: 5px;
+    height: 10px;
   }
 }
 
 #checkbox.checked {
+  background-color: #009688;
+  border-color: #009688;
+}
+
+#checkmark {
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
-  top: -4px;
-  left: 6px;
-  width: 10px;
-  height: 21px;
+  position: absolute;
+  top: -1px;
+  left: 4px;
+  width: 5px;
+  height: 10px;
+  border-style: solid;
   border-top: none;
   border-left: none;
   border-right-width: 2px;
   border-bottom-width: 2px;
-  border-color: #0f9d58;
-}
-
-/* checkbox unchecked animations */
-#checkbox.unchecked.checkmark {
-  -webkit-transform: rotate(45deg);
-  transform: rotate(45deg);
-  border-left: none;
-  border-top: none;
-  -webkit-animation: checkmark-shrink 140ms ease-out forwards;
-  animation: checkmark-shrink 140ms ease-out forwards;
-}
-
-@-webkit-keyframes checkmark-shrink {
-  0% {
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
-  100% {
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-@keyframes checkmark-shrink {
-  0% {
-    top: -4px;
-    left: 6px; 
-    width: 10px;
-    height: 21px;
-    border-right-width: 2px;
-    border-bottom-width: 2px;
-  }
-  100% {
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-}
-
-#checkbox.unchecked.box {
-  -webkit-animation: box-expand 140ms ease-out forwards;
-  animation: box-expand 140ms ease-out forwards;
-}
-
-@-webkit-keyframes box-expand {
-  0% {
-    -webkit-transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    -webkit-transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
-}
-
-@keyframes box-expand {
-  0% {
-    transform: rotate(45deg);
-    top: 13px;
-    left: 5px;
-    width: 4px;
-    height: 4px;
-  }
-  100% {
-    transform: rotate(0deg);
-    top: 0px;
-    left: 0px;
-    width: 18px;
-    height: 18px;
-  }
+  border-color: white;
 }
 
 /* label */
@@ -260,4 +137,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host([disabled]) #checkbox {
   opacity: 0.33;
   border-color: #5a5a5a;
+}
+
+:host([disabled][checked]) #checkbox {
+  background-color: #5a5a5a;
 }

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -31,6 +31,7 @@ To change the ink color for checked state:
 To change the checkbox checked color:
 
     paper-checkbox::shadow #checkbox.checked {
+      background-color: #4285f4;
       border-color: #4285f4;
     }
 
@@ -63,7 +64,9 @@ To change the checbox unchecked color:
   
     <paper-ripple id="ink" class="circle recenteringTouch" checked?="{{!checked}}"></paper-ripple>
      
-    <div id="checkbox" on-animationend="{{checkboxAnimationEnd}}" on-webkitAnimationEnd="{{checkboxAnimationEnd}}"></div>
+    <div id="checkbox">
+      <div id="checkmark" on-animationend="{{checkboxAnimationEnd}}" on-webkitAnimationEnd="{{checkboxAnimationEnd}}"></div>
+    </div>
     
   </div>
   
@@ -89,19 +92,15 @@ To change the checbox unchecked color:
     toggles: true,
 
     checkedChanged: function() {
-      var cl = this.$.checkbox.classList;
-      cl.toggle('checked', this.checked);
-      cl.toggle('unchecked', !this.checked);
-      cl.toggle('checkmark', !this.checked);
-      cl.toggle('box', this.checked);
+      this.$.checkbox.classList.toggle('checked', this.checked);
       this.setAttribute('aria-checked', this.checked ? 'true': 'false');
+      this.$.checkmark.classList.toggle('hidden', !this.checked);
       this.fire('core-change');
     },
 
     checkboxAnimationEnd: function() {
-      var cl = this.$.checkbox.classList;
-      cl.toggle('checkmark', this.checked && !cl.contains('checkmark'));
-      cl.toggle('box', !this.checked && !cl.contains('box'));
+      var cl = this.$.checkmark.classList;
+      cl.toggle('hidden', !this.checked && cl.contains('hidden'));
     }
 
   });


### PR DESCRIPTION
- CSS API change required: the checked checkbox must now also have its
  `background-color` set in addition to its `border-color`.
  
  ```
  paper-checkbox::shadow #checkbox.checked {
    background-color: #4285f4;
    border-color: #4285f4;
  }
  ```
- Add `[disabled]` and `[checked][disabled]` examples in the demo to
  show all permutations.
